### PR TITLE
chore: PRを勝手にマージしない

### DIFF
--- a/base.json
+++ b/base.json
@@ -11,6 +11,6 @@
   "schedule": ["after 10am on monday", "before 5pm on monday"],
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
-  "platformAutomerge": true,
+  "platformAutomerge": false,
   "labels": ["renovate"]
 }


### PR DESCRIPTION
# 概要

リリース前後などのタイミングを中心に、コードベースやライブラリが勝手に変わってほしくないタイミングがあるため platformAutomerge をfalseとさせてほしいです。

[`platformAutomerge`](https://docs.renovatebot.com/configuration-options/#platformautomerge)
